### PR TITLE
Refactor pact command handling

### DIFF
--- a/src/services/BalanceService.ts
+++ b/src/services/BalanceService.ts
@@ -1,12 +1,11 @@
 import Pact from 'pact-lang-api';
+import { executeLocal } from './PactCommandService';
 
 export async function getBalance(
   account: string,
   chainId: string
 ): Promise<number> {
-  const BASE = 'https://api.testnet.chainweb.com/chainweb/0.0';
   const networkId = 'testnet04';
-  const API_HOST = `${BASE}/${networkId}/chain/${chainId}/pact`;
   const cmd = {
     pactCode: `(coin.get-balance "${account}")`,
     envData: {},
@@ -20,6 +19,6 @@ export async function getBalance(
     ),
     networkId,
   };
-  const res = await Pact.fetch.local(cmd, API_HOST);
+  const res = await executeLocal(cmd, chainId, networkId);
   return res.result?.data ?? 0;
 }

--- a/src/services/PactCommandService.ts
+++ b/src/services/PactCommandService.ts
@@ -1,0 +1,13 @@
+import Pact from 'pact-lang-api';
+
+const BASE_URL = 'https://api.testnet.chainweb.com/chainweb/0.0';
+const DEFAULT_NETWORK_ID = 'testnet04';
+
+export async function executeLocal(
+  cmd: any,
+  chainId: string,
+  networkId: string = DEFAULT_NETWORK_ID
+): Promise<any> {
+  const API_HOST = `${BASE_URL}/${networkId}/chain/${chainId}/pact`;
+  return Pact.fetch.local(cmd, API_HOST);
+}


### PR DESCRIPTION
## Summary
- create `PactCommandService` to handle generic Pact interactions
- refactor `BalanceService` to use the new executor

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68485d8691208333bc462df745337bac