### PR TITLE
Add tab management features

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,16 @@
         cursor: pointer;
         background: #eee;
         margin-right: 2px;
+        user-select: none;
       }
       .tab.active {
         background: #fff;
         font-weight: bold;
+      }
+      .tab .close {
+        margin-left: 5px;
+        color: red;
+        cursor: pointer;
       }
       #editor {
         height: 200px;

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,5 +1,10 @@
-export const defaultPresets = [
-  `;; preset 1\n(command 1)`,
-  `;; preset 2\n(command 2)`,
-  `;; preset 3\n(command 3)`
+export interface Preset {
+  name: string;
+  content: string;
+}
+
+export const defaultPresets: Preset[] = [
+  { name: 'Preset 1', content: `;; preset 1\n(command 1)` },
+  { name: 'Preset 2', content: `;; preset 2\n(command 2)` },
+  { name: 'Preset 3', content: `;; preset 3\n(command 3)` }
 ];


### PR DESCRIPTION
## Summary
- refactor preset model to include name and content
- add renaming, deleting, and drag/drop reordering of tabs
- disable text selection on tabs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68486dee370483338e292ecdadcff494