### PR TITLE
Handle multi-key signing with SpireKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Open `http://localhost:5173` in your browser and connect the SpireKey extension 
 If you encounter issues with the wallet staying on the loading state, open the browser console and copy the log output. The application now prints messages with emojis (`🟢`, `🟡`, `🔵`, `🟠`) to help trace each step of the connection process.
 
 You can run `npm run dev` and then capture the console output after reloading the page. Share the logs so the issue can be diagnosed.
+
+## Multi-key accounts
+
+When an account has multiple keys the SpireKey adapter now picks the first non `WEBAUTHN` key and injects it into the command's `signers` before signing. Ensure your commands don't set a conflicting `pubKey`.

--- a/src/adapters/SpireKeyAdapter.ts
+++ b/src/adapters/SpireKeyAdapter.ts
@@ -38,6 +38,21 @@ export class SpireKeyAdapter implements IWalletAdapter {
 
   async signTransaction(cmd: any) {
     const networkId = cmd.networkId || 'testnet04';
+
+    const keys = this.acct.accountKeys || this.acct.keys || this.acct.guard?.keys || this.acct.keyset?.keys;
+    let pubKey = '';
+    if (Array.isArray(keys) && keys.length > 0) {
+      const k: any = keys.find((key: any) => {
+        const pk = typeof key === 'string' ? key : key.publicKey;
+        return pk && !pk.startsWith('WEBAUTHN');
+      }) || keys[0];
+      const pk = typeof k === 'string' ? k : k.publicKey;
+      if (pk) pubKey = pk.replace(/^[kr]:/, '');
+    }
+    if (!pubKey) throw new Error('SpireKeyAdapter: publicKey não encontrada');
+
+    cmd.signers = [{ pubKey, clist: [{ name: 'coin.GAS', args: [] }] }];
+
     const context = [
       {
         accountName: this.acct.accountName,


### PR DESCRIPTION
## Summary
- update `SpireKeyAdapter` to choose a proper `pubKey` and inject it into commands
- document how multi-key accounts are handled

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849bc9ca430833392d3086bbe8e11c5